### PR TITLE
Small changes to documentation

### DIFF
--- a/R/B-find-saddlepoint-mle.R
+++ b/R/B-find-saddlepoint-mle.R
@@ -5,7 +5,7 @@
 #' @title Find maximum likelihood estimates using the saddlepoint likelihood.
 #'
 #' @description
-#' This function uses the nloptr package for optimization to find the maximum likelihood estimates (MLEs). 
+#' This function uses the [`nloptr`] package for optimization to find the maximum likelihood estimates (MLEs). 
 #' It takes a CGF object along with various parameters related to the optimization procedure. 
 #' An alternative zeroth-order method can be enabled by setting the `zeroth.order` parameter to `TRUE`. 
 #' 
@@ -34,10 +34,10 @@
 #' @param discrepancy Logical. If `TRUE`, compute a discrepancy measure that approximates 
 #'   how different the saddlepoint approximation-based estimates are from the unknown true MLEs. Defaults to `FALSE`.
 #' @param user.ineq.constraint.function Optional user-defined inequality constraints. Defaults to `NULL`.
-#' @param opts.user A named list of options for the nloptr optimizer. This
+#' @param opts.user A named list of options for the [`nloptr`] optimizer. This
 #'   should be a subset of the following elements: ftol_abs (> 0),
 #'   maxeval (a positive integer), xtol_rel (> 0), print_level (0, 1, 2, or 3).
-#'   See the nloptr package documentation for more details about these options.
+#'   See the [`nloptr`] package documentation for more details about these options.
 #'   By default, ftol_abs = 0, maxeval = 1e4, xtol_rel = 1.0e-7, print_level = 0.
 #'   Note: The algorithm option is fixed to "NLOPT_LD_SLSQP" and cannot be changed by the user.
 #' @param zeroth.order A logical value indicating whether to use the zeroth-order saddlepoint likelihood. Defaults to FALSE, using the standard saddlepoint likelihood.
@@ -48,7 +48,7 @@
 #'     \item \code{MLEs.tvec, MLEs.theta}: The estimated saddlepoint \eqn{\hat{t}} and parameter vector \eqn{\hat{\theta}}.
 #'     \item \code{std.error}, \code{inverse.hessian}: If \code{std.error=TRUE}, these hold the standard errors and the inverse Hessian.
 #'     \item \code{discrepancy}: If \code{discrepancy=TRUE}, this is the approximated discrepancy between the resulting saddlepoint approximation-based MLEs and the unknown true MLEs.
-#'     \item \code{solution, status, message}: The raw output from \code{nloptr}.
+#'     \item \code{solution, status, message}: The raw output from [`nloptr`].
 #'   }
 #'
 #' @examples

--- a/R/C-PoissonCGF.R
+++ b/R/C-PoissonCGF.R
@@ -9,7 +9,7 @@
 #'
 #' A ready-to-use CGF object for the Poisson distribution. 
 #' 
-#' #' @details
+#' @details
 #' **Parameter Vector**: The `parameter_vector` for \code{PoissonCGF} is 
 #' interpreted as the rate \eqn{\lambda}. By default, this object is vectorized 
 #' for i.i.d. replicates of Poisson variables.

--- a/man/PoissonCGF.Rd
+++ b/man/PoissonCGF.Rd
@@ -15,7 +15,6 @@ PoissonCGF
 A ready-to-use CGF object for the Poisson distribution.
 }
 \details{
-#' @details
 \strong{Parameter Vector}: The \code{parameter_vector} for \code{PoissonCGF} is
 interpreted as the rate \eqn{\lambda}. By default, this object is vectorized
 for i.i.d. replicates of Poisson variables.

--- a/man/find.saddlepoint.MLE.Rd
+++ b/man/find.saddlepoint.MLE.Rd
@@ -44,10 +44,10 @@ how different the saddlepoint approximation-based estimates are from the unknown
 
 \item{user.ineq.constraint.function}{Optional user-defined inequality constraints. Defaults to \code{NULL}.}
 
-\item{opts.user}{A named list of options for the nloptr optimizer. This
+\item{opts.user}{A named list of options for the \code{\link[nloptr:nloptr]{nloptr::nloptr}} optimizer. This
 should be a subset of the following elements: ftol_abs (> 0),
 maxeval (a positive integer), xtol_rel (> 0), print_level (0, 1, 2, or 3).
-See the nloptr package documentation for more details about these options.
+See the \code{\link{nloptr}} package documentation for more details about these options.
 By default, ftol_abs = 0, maxeval = 1e4, xtol_rel = 1.0e-7, print_level = 0.
 Note: The algorithm option is fixed to "NLOPT_LD_SLSQP" and cannot be changed by the user.}
 
@@ -59,11 +59,11 @@ A list containing:
 \item \code{MLEs.tvec, MLEs.theta}: The estimated saddlepoint \eqn{\hat{t}} and parameter vector \eqn{\hat{\theta}}.
 \item \code{std.error}, \code{inverse.hessian}: If \code{std.error=TRUE}, these hold the standard errors and the inverse Hessian.
 \item \code{discrepancy}: If \code{discrepancy=TRUE}, this is the approximated discrepancy between the resulting saddlepoint approximation-based MLEs and the unknown true MLEs.
-\item \code{solution, status, message}: The raw output from \code{nloptr}.
+\item \code{solution, status, message}: The raw output from \code{\link[nloptr:nloptr]{nloptr::nloptr}}.
 }
 }
 \description{
-This function uses the nloptr package for optimization to find the maximum likelihood estimates (MLEs).
+This function uses the \code{\link{nloptr}} package for optimization to find the maximum likelihood estimates (MLEs).
 It takes a CGF object along with various parameters related to the optimization procedure.
 An alternative zeroth-order method can be enabled by setting the \code{zeroth.order} parameter to \code{TRUE}.
 }

--- a/man/find.saddlepoint.MLE.Rd
+++ b/man/find.saddlepoint.MLE.Rd
@@ -44,7 +44,7 @@ how different the saddlepoint approximation-based estimates are from the unknown
 
 \item{user.ineq.constraint.function}{Optional user-defined inequality constraints. Defaults to \code{NULL}.}
 
-\item{opts.user}{A named list of options for the \code{\link[nloptr:nloptr]{nloptr::nloptr}} optimizer. This
+\item{opts.user}{A named list of options for the \code{\link{nloptr}} optimizer. This
 should be a subset of the following elements: ftol_abs (> 0),
 maxeval (a positive integer), xtol_rel (> 0), print_level (0, 1, 2, or 3).
 See the \code{\link{nloptr}} package documentation for more details about these options.
@@ -59,7 +59,7 @@ A list containing:
 \item \code{MLEs.tvec, MLEs.theta}: The estimated saddlepoint \eqn{\hat{t}} and parameter vector \eqn{\hat{\theta}}.
 \item \code{std.error}, \code{inverse.hessian}: If \code{std.error=TRUE}, these hold the standard errors and the inverse Hessian.
 \item \code{discrepancy}: If \code{discrepancy=TRUE}, this is the approximated discrepancy between the resulting saddlepoint approximation-based MLEs and the unknown true MLEs.
-\item \code{solution, status, message}: The raw output from \code{\link[nloptr:nloptr]{nloptr::nloptr}}.
+\item \code{solution, status, message}: The raw output from \code{\link{nloptr}}.
 }
 }
 \description{


### PR DESCRIPTION
Two small changes in here:

1. There was an error in the `roxygen` code for `PoissonCGF()` that prevented the "Details" section heading from appearing properly.
2. I added links to the `nloptr()` help file in the `find.saddlepoint.MLE()` documentation, so that the user doesn't have to separately look up `?nloptr` themselves to figure out how to use the `opts.user` argument.